### PR TITLE
Remove release-drafter conditionals

### DIFF
--- a/.github/workflows/github-prepare-release.yml
+++ b/.github/workflows/github-prepare-release.yml
@@ -34,20 +34,11 @@ jobs:
           owner: ${{ inputs.owner }}
           repositories: ${{ inputs.repositories }}
 
-      - name: Get latest tag (draft or release)
-        run: |
-          echo "DETECTED_VERSION=$(gh api repos/${{ github.repository }}/releases | jq -r '.[0].tag_name')" >> "$GITHUB_ENV"
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
-
       - name: Update release draft
         id: draft
         uses: release-drafter/release-drafter@v6
         with:
           commitish: main
           disable-autolabeler: true
-          tag: ${{ env.DETECTED_VERSION < '1.0.0' && '1.0.0' || '' }}
-          version: ${{ env.DETECTED_VERSION }} < '1.0.0' && '1.0.0' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}


### PR DESCRIPTION
This PR removes the hacky attempt at creating a 1.0.0 release if none is detected.

This check fails if the draft version uses a leading v and subsequently assigns a 1.0.0 tag, which screws everything up.

Removing this code for now until I can think of a better approach. In the meantime workflows using this reusable workflow should be disabled until after the 1.0.0 release has been manually created.