### PR TITLE
Remove older os versions

### DIFF
--- a/.github/workflows/devcontainer-features-test.yml
+++ b/.github/workflows/devcontainer-features-test.yml
@@ -36,9 +36,7 @@ jobs:
       matrix:
         features: ${{ fromJSON(needs.changes.outputs.features) }}
         baseImage:
-          - ubuntu:focal
-          - ubuntu:jammy
-          - debian:11
+          - ubuntu:noble
           - debian:12
           - mcr.microsoft.com/devcontainers/base:ubuntu
           - mcr.microsoft.com/devcontainers/base:debian


### PR DESCRIPTION
This PR removes the following OS versions for feature tests:
- ubuntu:focal
- ubuntu:jammy
- debian:11

Some of the development tooling versions are too old to successfully build and test devcontainer features (ex: glibc)