### PR TITLE
Fix image path and remove unused command

### DIFF
--- a/.github/workflows/container-build-push.yml
+++ b/.github/workflows/container-build-push.yml
@@ -76,7 +76,7 @@ jobs:
   merge:
     needs:
       - build
-      - changes    
+      - changes
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     strategy:
@@ -104,9 +104,7 @@ jobs:
         id: version
         run: |
           if [[ -f "${{ matrix.images }}/get-version.sh" ]]; then
-            VERSION=$(cd "${{ matrix.images }}" && bash get-version.sh)
-            # Remove 'v' prefix if present
-            VERSION=${VERSION#v}
+            VERSION=$(cd "images/${{ matrix.images }}" && bash get-version.sh)
 
             # Split version into components
             IFS='.' read -ra PARTS <<< "$VERSION"


### PR DESCRIPTION
This PR removes the command to strip the v prefix (this is already handled in the get-version.sh script) and fixes the path for the image directories.