### PR TITLE
Modify container-build-push workflow for scheduled runs

### DIFF
--- a/.github/workflows/container-build-push.yml
+++ b/.github/workflows/container-build-push.yml
@@ -1,3 +1,4 @@
+---
 name: container-build-push
 
 on:
@@ -18,12 +19,23 @@ jobs:
   changes:
     runs-on: ubuntu-24.04
     outputs:
-      images: ${{ steps.filter.outputs.changes }}
+      images: ${{ steps.filter.outputs.changes || steps.schedule.outputs.images }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - uses: dorny/paths-filter@v3
+      - name: Get all images for scheduled runs
+        if: github.event_name == 'schedule'
+        id: schedule
+        run: |
+          # Extract all keys from filters.yml and format as JSON array
+          images=$(yq eval 'keys' ${{ inputs.filter_file_path }} | yq eval -o=json '.' | jq -c '.')
+          echo "images=${images}" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Detect changed images
+        if: github.event_name != 'schedule'
+        uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: ${{ inputs.filter_file_path }}
@@ -67,7 +79,7 @@ jobs:
           context: ${{ inputs.images_root_folder }}${{ matrix.images }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ghcr.io/${{ github.repository }}/${{ matrix.images }}
-          outputs: type=image,push-by-digest=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }},name-canonical=true,push=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          outputs: type=image,push-by-digest=${{ github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }},name-canonical=true,push=${{ github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
       - name: Export digest
         run: |
@@ -88,7 +100,7 @@ jobs:
     needs:
       - build
       - changes
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-24.04
     strategy:
       matrix:


### PR DESCRIPTION
This PR modifies the container-build-push workflow to permit scheduled runs to reuse the code.