### PR TITLE
Disable provenance for container builds

### DIFF
--- a/.github/workflows/container-build-push.yml
+++ b/.github/workflows/container-build-push.yml
@@ -79,6 +79,7 @@ jobs:
           context: ${{ inputs.images_root_folder }}${{ matrix.images }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ghcr.io/${{ github.repository }}/${{ matrix.images }}
+          provenance: false
           outputs: type=image,push-by-digest=${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }},name-canonical=true,push=${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
       - name: Export digest


### PR DESCRIPTION
This PR sets `provenance: false` since GHCR doesn't seem to have good support for it yet. Currently detected as an additional `unknown/unknown` OS, which is misleading.