### PR TITLE
Add Flux reusable workflows

### DIFF
--- a/.github/workflows/flux-e2e.yml
+++ b/.github/workflows/flux-e2e.yml
@@ -1,0 +1,176 @@
+---
+name: flux-e2e
+
+on:
+  workflow_call:
+    inputs:
+      flux_version:
+        description: Flux distribution version constraint.
+        required: false
+        type: string
+        default: 2.x
+      tenants:
+        description: JSON array of tenant directory names under ./tenants to deploy and validate.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Setup Flux CLI
+        uses: controlplaneio-fluxcd/distribution/actions/setup@f2b659f0cec358552f981171c5f98e4972183b0c # v2.7.5
+
+      - name: Setup Kubernetes (KIND)
+        uses: helm/kind-action@92086f6be054225fa813e0a4b13787fc9088faab # v1.13.0
+        with:
+          cluster_name: flux-test
+          wait: 1m
+
+      - name: Verify cluster
+        run: |
+          kubectl cluster-info
+          kubectl get nodes
+
+      - name: Install Flux Operator
+        run: |
+          kubectl apply -f https://github.com/controlplaneio-fluxcd/flux-operator/releases/latest/download/install.yaml
+          kubectl -n flux-system wait deployment/flux-operator --for=condition=Available --timeout=2m
+
+      - name: Create test FluxInstance
+        run: |
+          kubectl apply -f - <<EOF
+          ---
+          apiVersion: fluxcd.controlplane.io/v1
+          kind: FluxInstance
+          metadata:
+            name: flux
+            namespace: flux-system
+          spec:
+            distribution:
+              version: "${{ inputs.flux_version }}"
+              registry: "ghcr.io/fluxcd"
+            kustomize:
+              patches:
+                - target:
+                    kind: Kustomization
+                  patch: |
+                    - op: replace
+                      path: /spec/interval
+                      value: 1m
+          EOF
+
+      - name: Wait for Flux to be ready
+        run: |
+          kubectl -n flux-system wait fluxinstance/flux --for=condition=Ready --timeout=3m
+
+      - name: Create test tenants Kustomizations
+        run: |
+          kubectl apply -f - <<EOF
+          ---
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: flux-system
+          ---
+          apiVersion: source.toolkit.fluxcd.io/v1
+          kind: GitRepository
+          metadata:
+            name: fleet-test
+            namespace: flux-system
+          spec:
+            interval: 1m
+            url: ${{ github.server_url }}/${{ github.repository }}
+            ref:
+              branch: ${{ github.head_ref || github.ref_name }}
+          $(for tenant in $(echo '${{ inputs.tenants }}' | jq -r '.[]'); do
+          cat <<TENANT
+          ---
+          apiVersion: kustomize.toolkit.fluxcd.io/v1
+          kind: Kustomization
+          metadata:
+            name: tenants-${tenant}
+            namespace: flux-system
+          spec:
+            interval: 1m
+            retryInterval: 30s
+            path: ./tenants/${tenant}
+            prune: true
+            sourceRef:
+              kind: GitRepository
+              name: fleet-test
+          TENANT
+          done)
+          EOF
+
+      - name: Wait for tenants Kustomizations to reconcile
+        timeout-minutes: 3
+        run: |
+          for tenant in $(echo '${{ inputs.tenants }}' | jq -r '.[]'); do
+            echo "Waiting for tenants-${tenant} Kustomization to reconcile..."
+            kubectl -n flux-system wait kustomization/tenants-${tenant} --for=condition=Ready --timeout=3m || true
+          done
+
+      - name: Verify ResourceSets created
+        run: |
+          echo "=== ResourceSets ==="
+          kubectl get resourcesets -A
+
+          echo ""
+          echo "=== ResourceSet: infra ==="
+          kubectl -n flux-system get resourceset infra -o yaml || echo "ResourceSet 'infra' not found"
+
+          echo ""
+          echo "=== ResourceSet: apps ==="
+          kubectl -n flux-system get resourceset apps -o yaml || echo "ResourceSet 'apps' not found"
+
+      - name: Validate ResourceSet templates
+        run: |
+          echo "=== Checking if ResourceSets processed inputs ==="
+
+          # Check if any namespaces were created by ResourceSets
+          kubectl get namespaces -l toolkit.fluxcd.io/component
+
+          # Check if any Kustomizations were created
+          kubectl get kustomizations -A
+
+          # Check if any OCIRepositories were created
+          kubectl get ocirepositories -A
+
+      - name: Show Flux status
+        if: always()
+        run: |
+          echo "=== Flux Installation ==="
+          kubectl -n flux-system get fluxinstance
+
+          echo ""
+          echo "=== All Flux Resources ==="
+          flux get all --all-namespaces
+
+      - name: Debug on failure
+        if: failure()
+        run: |
+          echo "=== Flux Operator Logs ==="
+          kubectl -n flux-system logs deployment/flux-operator --tail=100
+
+          echo ""
+          echo "=== Kustomize Controller Logs ==="
+          kubectl -n flux-system logs deployment/kustomize-controller --tail=100 || true
+
+          echo ""
+          echo "=== Source Controller Logs ==="
+          kubectl -n flux-system logs deployment/source-controller --tail=100 || true
+
+          echo ""
+          echo "=== All Resources in flux-system ==="
+          kubectl -n flux-system get all
+
+          echo ""
+          echo "=== Events ==="
+          kubectl -n flux-system get events --sort-by='.lastTimestamp'

--- a/.github/workflows/flux-publish-oci.yml
+++ b/.github/workflows/flux-publish-oci.yml
@@ -1,0 +1,73 @@
+---
+name: flux-publish-oci
+
+on:
+  workflow_call:
+    inputs:
+      component_name:
+        description: Component name (e.g. cert-manager for infra/apps). Leave empty to publish the repo root as a single artifact (e.g. fleet).
+        required: false
+        type: string
+        default: ""
+      artifact_path:
+        description: Directory containing components (e.g. './components' for infra/apps). Leave as './' for repos published as a single artifact (e.g. fleet).
+        required: false
+        type: string
+        default: ./
+      cosign_version:
+        description: Cosign release version for keyless signing.
+        type: string
+        default: v2.6.1
+    secrets:
+      ghcr_token:
+        description: Token for GHCR authentication (typically secrets.GITHUB_TOKEN).
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write # For cosign keyless signing
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Setup Flux CLI
+        uses: controlplaneio-fluxcd/distribution/actions/setup@f2b659f0cec358552f981171c5f98e4972183b0c # v2.7.5
+
+      - name: Setup cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        with:
+          cosign-release: ${{ inputs.cosign_version }}
+
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.ghcr_token }}
+
+      - name: Push OCI artifact
+        if: github.event_name != 'pull_request'
+        uses: controlplaneio-fluxcd/distribution/actions/push@f2b659f0cec358552f981171c5f98e4972183b0c # v2.7.5
+        id: push
+        with:
+          repository: ghcr.io/${{ github.repository }}${{ inputs.component_name != '' && format('/{0}', inputs.component_name) || '' }}
+          path: ${{ inputs.component_name != '' && format('{0}/{1}', inputs.artifact_path, inputs.component_name) || inputs.artifact_path }}
+          diff-tag: latest # Only push if different from :latest
+
+      - name: Sign artifact
+        if: github.event_name != 'pull_request' && steps.push.outputs.pushed == 'true'
+        run: cosign sign --yes $DIGEST_URL
+        env:
+          DIGEST_URL: ${{ steps.push.outputs.digest-url }}
+
+      - name: Validate artifact (PR only)
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "::notice::PR validation - ${{ inputs.component_name != '' && inputs.component_name || 'root' }} artifact build successful"
+          flux push artifact oci://localhost:5000/test:pr --path="${{ inputs.component_name != '' && format('{0}/{1}', inputs.artifact_path, inputs.component_name) || inputs.artifact_path }}" || true


### PR DESCRIPTION
This PR adds reusable workflows for Flux. This permits artifacts builds and end-to-end testing for changes in Flux Kubernetes repos.