### PR TITLE
Add GitHub App to updatecli workflow

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -16,9 +16,13 @@ on:
         description: Path to the updatecli values file.
         required: true
         type: string
+      gh_app_id:
+        description: GitHub App ID.
+        required: true
+        type: string
     secrets:
-      token:
-        description: Token for GitHub API access (typically secrets.GITHUB_TOKEN).
+      gh_app_private_key:
+        description: GitHub App private key.
         required: true
 
 permissions:
@@ -29,6 +33,15 @@ jobs:
   automerge:
     runs-on: ubuntu-24.04
     steps:
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        id: app_token
+        with:
+          app-id: ${{ inputs.gh_app_id }}
+          private-key: ${{ secrets.gh_app_private_key }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
@@ -38,12 +51,20 @@ jobs:
       - name: Run updatecli (automerge)
         run: updatecli apply --config "${{ inputs.automerge_config }}" --values "${{ inputs.values }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.token }}
-          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
 
   breaking:
     runs-on: ubuntu-24.04
     steps:
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        id: app_token
+        with:
+          app-id: ${{ inputs.gh_app_id }}
+          private-key: ${{ secrets.gh_app_private_key }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
@@ -54,5 +75,4 @@ jobs:
         continue-on-error: true # Expected to fail when no breaking versions exist
         run: updatecli apply --config "${{ inputs.breaking_config }}" --values "${{ inputs.values }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.token }}
-          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}


### PR DESCRIPTION
This PR adds a GitHub App to the updatecli workflow in order to trigger additional workflows beyond this one.