### PR TITLE
Remove workflow permissions and set env vars for steps

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -25,10 +25,6 @@ on:
         description: GitHub App private key.
         required: true
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   automerge:
     runs-on: ubuntu-24.04
@@ -51,7 +47,8 @@ jobs:
       - name: Run updatecli (automerge)
         run: updatecli apply --config "${{ inputs.automerge_config }}" --values "${{ inputs.values }}"
         env:
-          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+          UPDATECLI_GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+          UPDATECLI_GITHUB_USERNAME: x-access-token
 
   breaking:
     runs-on: ubuntu-24.04
@@ -75,4 +72,5 @@ jobs:
         continue-on-error: true # Expected to fail when no breaking versions exist
         run: updatecli apply --config "${{ inputs.breaking_config }}" --values "${{ inputs.values }}"
         env:
-          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+          UPDATECLI_GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+          UPDATECLI_GITHUB_USERNAME: x-access-token


### PR DESCRIPTION
This PR removes the permissions set at the workflow level; this is instead handled by the GitHub App for each step.

Additionally the env vars passed to the updatecli steps have been updated to align with what the tool expects as a fallback.

The preferred method, passing the raw client_id, installation_id, and private_key makes me uncomfortable so I am exploring other approaches to make this work.