### PR TITLE
Fix renovatebot repo detection

### DIFF
--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -42,3 +42,4 @@ jobs:
         env:
           RENOVATE_PLATFORM_COMMIT: 'true'
           LOG_LEVEL: 'debug'
+          RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'


### PR DESCRIPTION
Renovatebot needs to know which repo(s) to run against.