### PR TITLE
Add explicit permission for metadata to renovatebot workflow

### DIFF
--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           app-id: ${{ inputs.gh_app_id }}
           private-key: ${{ secrets.gh_app_private_key }}
+          permission-metadata: read
           permission-contents: write
           permission-pull-requests: write
 


### PR DESCRIPTION
Fixes a GraphQL permissions issue.