### PR TITLE
Remove explicit token permissions for renovatebot

### DIFF
--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -28,9 +28,6 @@ jobs:
         with:
           app-id: ${{ inputs.gh_app_id }}
           private-key: ${{ secrets.gh_app_private_key }}
-          permission-metadata: read
-          permission-contents: write
-          permission-pull-requests: write
 
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
To try and solve an odd graphql error, I am removing the explicit token permissions.

```
  POST https://api.github.com/graphql = (code=ERR_NON_2XX_3XX_RESPONSE, statusCode=401 retryCount=0)                                                                                                                                                                                                                                                                                                                                                                                                     
  github.com token 401 unauthorized                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
  GitHub failure: Bad credentials                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  hostType: "github-digest"                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
  packageName: "bendwyer/github-workflows" 
```