### PR TITLE
Move TS_OAUTH_CLIENT_ID to inputs:

### DIFF
--- a/.github/workflows/talos-sync.yml
+++ b/.github/workflows/talos-sync.yml
@@ -22,12 +22,13 @@ on:
         required: false
         type: boolean
         default: false
+      ts_oauth_client_id:
+        description: Tailscale OAuth client ID.
+        required: true
+        type: string
     secrets:
       SOPS_AGE_KEY:
         description: age private key for SOPS decryption.
-        required: true
-      TS_OAUTH_CLIENT_ID:
-        description: Tailscale OAuth client ID.
         required: true
       TS_OAUTH_SECRET:
         description: Tailscale OAuth client secret.
@@ -117,7 +118,7 @@ jobs:
       - name: Connect to Tailscale
         uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade # v3
         with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-client-id: ${{ inputs.ts_oauth_client_id }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:github
 


### PR DESCRIPTION
This PR moves the Tailscale OAuth client ID from being treated as a secret to being treated as a user input.