### PR TITLE
Fix promql parser error

### DIFF
--- a/.github/workflows/k8s-monitoring-publish-oci.yml
+++ b/.github/workflows/k8s-monitoring-publish-oci.yml
@@ -71,6 +71,10 @@ jobs:
               [ -f "$file" ] || continue
               mkdir -p "manifests/${artifact}"
 
+              # Workaround: replace \. with . in PromQL regex matchers for Prometheus 3.x compatibility.
+              # Upstream issue: https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/1016
+              sed -i 's/\\\././g' "$file"
+
               export RULE_NAME="${artifact}-${type}"
               echo "  ${type} → ${artifact}"
               envsubst '${RULE_NAME}' < templates/prometheusrule.yaml > "manifests/${artifact}/prometheusrule-${type}.yaml"


### PR DESCRIPTION
This PR replaces `\.` escapes with `.` in PrometheusRules to avoid PromQL parser rejections when adding the alerts/rules from the kubernetes-mixin.

Tracked in [#1016](https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/1016) and caused by [#1008](https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/1008)