### PR TITLE
Fix permissions for renovate workflow

### DIFF
--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -31,6 +31,8 @@ jobs:
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
+          permission-statuses: write
+          permission-vulnerability-alerts: read
 
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
Adds additional permissions to clear 403s when running the workflow.