### PR TITLE
fix(github-app-client-id): replace deprecated app-id with client-id

### DIFF
--- a/.github/workflows/github-action-promote-major-version.yml
+++ b/.github/workflows/github-action-promote-major-version.yml
@@ -4,8 +4,8 @@ name: github-action-promote-major-version
 on:
   workflow_call:
     inputs:
-      gh_app_id:
-        description: GitHub App ID
+      gh_client_id:
+        description: GitHub App client ID
         required: true
         type: string
       owner:
@@ -19,17 +19,17 @@ on:
     secrets:
       gh_app_private_key:
         description: GitHub App private key
-        required: true    
+        required: true
 
 jobs:
   github-action-promote-major-version:
     runs-on: ubuntu-24.04
     steps:
       - name: Generate GitHub App token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app_token
         with:
-          app-id: ${{ inputs.gh_app_id }}
+          client-id: ${{ inputs.gh_client_id }}
           private-key: ${{ secrets.gh_app_private_key }}
           owner: ${{ inputs.owner }}
           repositories: ${{ inputs.repositories }}

--- a/.github/workflows/github-label.yml
+++ b/.github/workflows/github-label.yml
@@ -3,8 +3,8 @@ name: label
 on:
   workflow_call:
     inputs:
-      gh_app_id:
-        description: GitHub App ID
+      gh_client_id:
+        description: GitHub App client ID
         required: true
         type: string
       owner:
@@ -25,16 +25,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app_token
         with:
-          app-id: ${{ inputs.gh_app_id }}
+          client-id: ${{ inputs.gh_client_id }}
           private-key: ${{ secrets.gh_app_private_key }}
           owner: ${{ inputs.owner }}
           repositories: ${{ inputs.repositories }}
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Ensure labels exist
         env:

--- a/.github/workflows/github-prepare-release.yml
+++ b/.github/workflows/github-prepare-release.yml
@@ -4,8 +4,8 @@ name: prepare-release
 on:
   workflow_call:
     inputs:
-      gh_app_id:
-        description: GitHub App ID
+      gh_client_id:
+        description: GitHub App client ID
         required: true
         type: string
       owner:
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app_token
         with:
-          app-id: ${{ inputs.gh_app_id }}
+          client-id: ${{ inputs.gh_client_id }}
           private-key: ${{ secrets.gh_app_private_key }}
           owner: ${{ inputs.owner }}
           repositories: ${{ inputs.repositories }}

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -4,8 +4,8 @@ name: terraform-docs
 on:
   workflow_call:
     inputs:
-      gh_app_id:
-        description: GitHub App ID
+      gh_client_id:
+        description: GitHub App client ID
         required: true
         type: string
       owner:
@@ -16,7 +16,7 @@ on:
         description: Path to the README file.
         required: false
         default: README.md
-        type: string        
+        type: string
       repositories:
         description: Comma separated list of repositories to grant access to. If 'owner' is set and 'repositories' is empty, access will be scoped to all repositories in the provided repository owner's installation. If 'owner' and 'repositories' are empty, access will be scoped to only the current repository.
         required: false
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app_token
         with:
-          app-id: ${{ inputs.gh_app_id }}
+          client-id: ${{ inputs.gh_client_id }}
           private-key: ${{ secrets.gh_app_private_key }}
           owner: ${{ inputs.owner }}
           repositories: ${{ inputs.repositories }}
@@ -53,7 +53,7 @@ jobs:
         shell: bash
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0

--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -4,8 +4,8 @@ name: terraform-lint
 on:
   workflow_call:
     inputs:
-      gh_app_id:
-        description: GitHub App ID
+      gh_client_id:
+        description: GitHub App client ID
         required: true
         type: string
       owner:
@@ -29,16 +29,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app_token
         with:
-          app-id: ${{ inputs.gh_app_id }}
+          client-id: ${{ inputs.gh_client_id }}
           private-key: ${{ secrets.gh_app_private_key }}
           owner: ${{ inputs.owner }}
           repositories: ${{ inputs.repositories }}
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.app_token.outputs.token }}
 
@@ -79,7 +79,7 @@ jobs:
       - fmt
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4


### PR DESCRIPTION
Changes the GitHub App behavior for workflows associated with Terraform. These changes will break some other repo runs, but I will have to solve them as they come.