### PR TITLE
fix(k8s-monitoring-publish-oci): map snmp-observ-lib subdir to snmp-mixin artifact

### DIFF
--- a/.github/workflows/k8s-monitoring-publish-oci.yml
+++ b/.github/workflows/k8s-monitoring-publish-oci.yml
@@ -131,6 +131,7 @@ jobs:
             # Normalize names to match artifact directories
             case "$name" in
               node-mixin) name="node-exporter-mixin" ;;
+              snmp-observ-lib) name="snmp-mixin" ;;
             esac
 
             VERSIONS[$name]="$version"


### PR DESCRIPTION
The new `snmp-mixin` artifact in `k8s-monitoring` is built from the `snmp-observ-lib` jsonnet-libs subdir, so the artifact name and the dependency subdir differ. The publish matrix keys the version map by subdir basename (`snmp-observ-lib`) but looks it up by artifact name (`snmp-mixin`), so without a normalization the tag falls back to `0.0.0` instead of the SHA-derived `YYYY.MM.DD`.

This adds one `case` line, exactly like the existing `node-mixin` to `node-exporter-mixin` mapping.

Merge this before the `k8s-monitoring` snmp-mixin PR so the first publish tags correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)