### PR TITLE
feat(renovate): allow jb update post-upgrade command

### DIFF
--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -47,3 +47,4 @@ jobs:
           RENOVATE_PLATFORM_COMMIT: 'true'
           LOG_LEVEL: 'debug'
           RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
+          RENOVATE_ALLOWED_COMMANDS: '["^jb update$"]'


### PR DESCRIPTION
## What

Adds `RENOVATE_ALLOWED_COMMANDS: '["^jb update$"]'` to the `Run Renovate` step in the reusable `renovatebot.yml` workflow.

## Why

`k8s-monitoring` runs a `postUpgradeTasks` command of `jb update` to refresh `jsonnetfile.lock.json` after mixin bumps. `allowedCommands` is a self-hosted, admin-only Renovate setting that is deliberately ignored when set in a repo `renovate.json` (security). Because the reusable runner never supplied it, the post-task was rejected and every affected PR carried an "Artifact update problem" comment:

```
Post-upgrade command 'jb update' has not been added to the allowed list in allowedCommands
```

Confirmed in the debug logs of a real run (`WARN: Post-upgrade task did not match any on allowedCommands list`, `cmd: jb update`).

## Notes

- The command runs in Renovate's default (slim) image, which auto-installs `jb` at runtime via containerbase (`install-tool jb v0.6.0`, verified in logs), so the binary is available; the only missing piece was the allow-list entry.
- Pattern is anchored (`^jb update$`) so it permits only the exact command, not anything containing "jb update".
- Only affects repos that define a `jb update` post-upgrade task; no effect on other consumers of this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)