### PR TITLE
fix(publish-oci): retry cosign sign on transient failures

### DIFF
--- a/.github/workflows/flux-publish-oci.yml
+++ b/.github/workflows/flux-publish-oci.yml
@@ -78,7 +78,16 @@ jobs:
 
       - name: Sign artifact
         if: github.event_name != 'pull_request' && steps.push.outputs.pushed == 'true'
-        run: cosign sign --yes $DIGEST_URL
+        run: |
+          for attempt in 1 2 3; do
+            if cosign sign --yes "$DIGEST_URL"; then
+              exit 0
+            fi
+            echo "::warning::cosign sign attempt ${attempt} failed; retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
+          echo "::error::cosign sign failed after 3 attempts"
+          exit 1
         env:
           DIGEST_URL: ${{ steps.push.outputs.digest-url }}
 

--- a/.github/workflows/k8s-monitoring-publish-oci.yml
+++ b/.github/workflows/k8s-monitoring-publish-oci.yml
@@ -200,6 +200,15 @@ jobs:
 
       - name: Sign artifact
         if: steps.push.outputs.pushed == 'true'
-        run: cosign sign --yes $DIGEST_URL
+        run: |
+          for attempt in 1 2 3; do
+            if cosign sign --yes "$DIGEST_URL"; then
+              exit 0
+            fi
+            echo "::warning::cosign sign attempt ${attempt} failed; retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
+          echo "::error::cosign sign failed after 3 attempts"
+          exit 1
         env:
           DIGEST_URL: ${{ steps.push.outputs.digest-url }}


### PR DESCRIPTION
## Problem

The `Sign artifact` step (`cosign sign`) intermittently fails with transient sigstore errors, e.g.:

```
Error: signing [...]: signing bundle: error signing bundle: stream error: stream ID 1; INTERNAL_ERROR; received from peer
```

The artifact `push` step runs first and succeeds, so the artifact is already published; the signing blip then fails the whole job with no retry. This has chewed up red publish runs on an otherwise-successful push.

## Fix

Wrap `cosign sign` in a retry loop: up to 3 attempts with linear backoff (10s, 20s), a warning per failed attempt, and a hard failure only if all 3 fail. Applied to both `flux-publish-oci.yml` and `k8s-monitoring-publish-oci.yml`, which had the identical step.

No behavior change on success; transient signing-backend errors are now absorbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)