### PR TITLE
fix(coder-image-build-push): show target platform in build job names

### DIFF
--- a/.github/workflows/coder-image-build-push.yml
+++ b/.github/workflows/coder-image-build-push.yml
@@ -82,6 +82,7 @@ jobs:
           echo "Images: ${images}"
 
   build:
+    name: build ${{ matrix.image }} (${{ matrix.platform }})
     needs: detect
     if: needs.detect.outputs.images != '[]'
     runs-on: ${{ matrix.runner }}
@@ -92,25 +93,26 @@ jobs:
       fail-fast: false
       matrix:
         image: ${{ fromJSON(needs.detect.outputs.images) }}
-        runner:
-          - ubuntu-24.04
-          - ubuntu-24.04-arm
+        platform:
+          - linux/amd64
+          - linux/arm64
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     env:
       PUSH: ${{ github.event_name != 'pull_request' }}
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - name: Normalize platform
+      - name: Platform spec
         id: platform
         shell: bash
-        run: |
-          case "${{ runner.arch }}" in
-            X64)   arch=amd64 ;;
-            ARM64) arch=arm64 ;;
-            *)     echo "unsupported arch: ${{ runner.arch }}" >&2; exit 1 ;;
-          esac
-          echo "spec=linux-${arch}" >> "${GITHUB_OUTPUT}"
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "spec=${PLATFORM//\//-}" >> "${GITHUB_OUTPUT}"
 
       - name: Image reference (lowercase)
         id: image
@@ -133,6 +135,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.images_root }}/${{ matrix.image }}
+          platforms: ${{ matrix.platform }}
           provenance: false
           cache-from: type=gha,scope=${{ matrix.image }}-${{ steps.platform.outputs.spec }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ steps.platform.outputs.spec }}


### PR DESCRIPTION
## Why

The build matrix keyed on the runner label, so jobs rendered as:

- `build (coder-base, ubuntu-24.04)`
- `build (coder-base, ubuntu-24.04-arm)`

That tells you which runner ran, not what the job builds, and `ubuntu-24.04` vs `ubuntu-24.04-arm` is an indirect way to read the target arch.

## What

- Add an explicit `platform` matrix axis (`linux/amd64`, `linux/arm64`) mapped to its native runner via `include`.
- Set a custom job `name:` so jobs read **`build coder-base (linux/amd64)`** / **`build coder-base (linux/arm64)`**.
- Pass `platforms: ${{ matrix.platform }}` to the build step (explicit instead of relying on native runner arch).
- Derive the platform spec (cache scope + digest artifact names) from `matrix.platform` rather than `runner.arch`, dropping the `case` block.

No change to what gets built or published; multi-arch digests and the manifest-list merge are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)