### PR TITLE
Fix detect step for zero-changed-images in coder-image-build-push

### DIFF
--- a/.github/workflows/coder-image-build-push.yml
+++ b/.github/workflows/coder-image-build-push.yml
@@ -71,9 +71,10 @@ jobs:
               # Cascade: a base-image change rebuilds all derived images.
               if echo "${changed}" | grep -qx "${{ inputs.base_image }}"; then
                 images=$(all)
+              elif [[ -n "${changed}" ]]; then
+                images=$(printf '%s\n' "${changed}" | jq -R . | jq -sc .)
               else
-                images=$(printf '%s\n' "${changed}" | grep -v '^$' | jq -R . | jq -sc . || echo '[]')
-                [[ -z "${images}" ]] && images='[]'
+                images='[]'
               fi
             fi
           fi


### PR DESCRIPTION
## Problem
A push or PR to a consumer repo (e.g. `coder-images`) that changes **no image directories** — for example a workflow-only or docs-only change — fails the `detect` job with:

```
Images: []
[]
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '[]'
```

## Cause
In the detect step, when `changed` is empty, `grep -v '^$'` matches nothing and exits non-zero under `pipefail`, so `|| echo '[]'` runs **in addition to** the trailing `jq -sc` that already emitted `[]`. The result is a two-line value `[]\n[]`, and `echo "images=$images" >> $GITHUB_OUTPUT` then writes a stray `[]` line that GitHub Actions can't parse.

## Fix
Replace the fragile `grep | jq | jq || echo` pipeline with an explicit branch: base-image changed -> all; some images changed -> the JSON list; nothing changed -> `[]`. Always a single clean array. A no-image change becomes a clean no-op, since `build`/`publish` are already gated on `needs.detect.outputs.images != '[]'`.

Verified locally: empty -> `[]`, `coder-base coder-python` -> `["coder-base","coder-python"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)