### PR TITLE
feat(terraform-lint): add working_directory input for validate

### DIFF
--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -16,6 +16,11 @@ on:
         description: Comma separated list of repositories to grant access to. If 'owner' is set and 'repositories' is empty, access will be scoped to all repositories in the provided repository owner's installation. If 'owner' and 'repositories' are empty, access will be scoped to only the current repository.
         required: false
         type: string
+      working_directory:
+        description: Directory to run terraform init/validate in, relative to the repo root. Defaults to the repo root.
+        required: false
+        type: string
+        default: "."
     secrets:
       gh_app_private_key:
         description: GitHub App private key
@@ -85,6 +90,7 @@ jobs:
         uses: hashicorp/setup-terraform@v4
 
       - name: terraform init
+        working-directory: ${{ inputs.working_directory }}
         run: |
           terraform init \
             -no-color \
@@ -93,6 +99,7 @@ jobs:
         shell: bash
 
       - name: terraform validate
+        working-directory: ${{ inputs.working_directory }}
         run: |
           terraform validate \
             -no-color


### PR DESCRIPTION
Adds an optional `working_directory` input (default `"."`) to the `terraform-lint` reusable workflow. The `validate` job's `terraform init`/`validate` now run in that directory, so repos whose terraform lives in a subdirectory (e.g. `coder-config/templates/kubernetes`) can validate without a root-level config.

- `fmt` is unchanged (stays repo-root `-recursive`).
- Default `"."` preserves current behavior for all existing callers (root-level terraform repos).

Enables a `coder-config` CI thin-caller for an all-green required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)