### PR TITLE
feat: add node-test reusable workflow

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -1,0 +1,54 @@
+---
+name: node-test
+
+# Install dependencies and run checks/tests for a Node.js project. Mirrors
+# python-test.yml: the caller supplies the install and test commands, so this
+# stays generic across repos (lint/typecheck/format are composed by the caller).
+
+on:
+  workflow_call:
+    inputs:
+      node_version:
+        description: Node.js version to install.
+        required: false
+        type: string
+        default: "22"
+      install_command:
+        description: Shell command to install dependencies. Run from working_directory.
+        required: false
+        type: string
+        default: npm ci
+      test_command:
+        description: Shell command to run checks/tests. Run from working_directory.
+        required: false
+        type: string
+        default: npm test
+      working_directory:
+        description: Directory to run install_command and test_command from. Defaults to repo root.
+        required: false
+        type: string
+        default: "."
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: ${{ inputs.install_command }}
+        shell: bash
+
+      - name: Run checks
+        run: ${{ inputs.test_command }}
+        shell: bash


### PR DESCRIPTION
## Summary

Adds a `node-test` reusable workflow (`workflow_call`) for Node.js project CI, alongside the existing `python-test` / `terraform-test`.

Mirrors `python-test.yml`: the caller supplies `install_command` (default `npm ci`) and `test_command` (default `npm test`), plus optional `node_version` (default `22`) and `working_directory`. Lint/typecheck/format are composed by the caller, so the workflow stays generic. `actions/checkout` and `actions/setup-node` are SHA-pinned with version comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)