### PR TITLE
fix(omni-sync): give omnictl a real template file for v1.9 file refs

### DIFF
--- a/.github/workflows/omni-sync.yml
+++ b/.github/workflows/omni-sync.yml
@@ -170,9 +170,15 @@ jobs:
             fi
 
             echo "Validating cluster: $cluster_name"
-            pushd "$cluster_dir" > /dev/null
-            sops -d cluster.yaml | omnictl cluster template validate -f /dev/stdin
-            popd > /dev/null
+            # omnictl v1.9+ needs a real template file to resolve `file:` patch
+            # refs; decrypt to a private temp file, never leaving plaintext behind.
+            tmpname="cluster.decrypted.$$.yaml"
+            tmp="${cluster_dir}${tmpname}"
+            trap 'rm -f "$tmp"' EXIT
+            ( umask 077; sops -d "${cluster_dir}cluster.yaml" > "$tmp" )
+            ( cd "$cluster_dir" && omnictl cluster template validate -f "$tmpname" --allowed-dir ../../ )
+            rm -f "$tmp"
+            trap - EXIT
           done
 
   sync:
@@ -327,13 +333,17 @@ jobs:
             fi
 
             echo "Syncing cluster: $cluster_name"
-            pushd "$cluster_dir" > /dev/null
-
+            # omnictl v1.9+ needs a real template file to resolve `file:` patch
+            # refs; decrypt to a private temp file, never leaving plaintext behind.
+            tmpname="cluster.decrypted.$$.yaml"
+            tmp="${cluster_dir}${tmpname}"
+            trap 'rm -f "$tmp"' EXIT
+            ( umask 077; sops -d "${cluster_dir}cluster.yaml" > "$tmp" )
             if [[ "$dry_run" == "true" ]]; then
-              sops -d cluster.yaml | omnictl cluster template sync -f /dev/stdin --dry-run
+              ( cd "$cluster_dir" && omnictl cluster template sync -f "$tmpname" --allowed-dir ../../ --dry-run )
             else
-              sops -d cluster.yaml | omnictl cluster template sync -f /dev/stdin
+              ( cd "$cluster_dir" && omnictl cluster template sync -f "$tmpname" --allowed-dir ../../ )
             fi
-
-            popd > /dev/null
+            rm -f "$tmp"
+            trap - EXIT
           done


### PR DESCRIPTION
## Why

omnictl v1.9 resolves cluster-template `file:` references against the template file's own directory and rejects paths that escape it. The workflow piped the decrypted template via `-f /dev/stdin`, which anchors resolution to `/dev`, so every `file:` patch reference now fails with `path escapes from parent`.

## Change

In the `validate` and `sync` steps, decrypt the template to a private (`umask 077`) temp file in the cluster directory and pass `-f <file> --allowed-dir ../../` so shared patches at the repo root resolve. The temp file is removed on success and via an `EXIT` trap on failure, so plaintext never persists.

This uses omnictl's stable regular-file input path rather than stdin. Consumers should also pin `omnictl_version` so tool changes are deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)