### PR TITLE
fix(coder-image-build-push): emit unpadded CalVer tags

### DIFF
--- a/.github/workflows/coder-image-build-push.yml
+++ b/.github/workflows/coder-image-build-push.yml
@@ -6,8 +6,9 @@
 #     `images_root` is an image, discovered with `ls`.
 #   - container-build-push style multi-arch: native amd64 + arm64 runners build
 #     per-arch by digest, then a merge job creates the manifest list.
-#   - k8s-monitoring style CalVer tagging: `YYYY.MM.DD` (build date) so
-#     downstream Renovate consumers can pin the digest and track new dates.
+#   - CalVer tagging: `YYYY.MM.DD` (build date) so downstream Renovate consumers
+#     can pin the digest and track new dates. CalVer `MM`/`DD`, not `0M`/`0D`:
+#     leading zeros are invalid semver and `semver-coerced` silently skips them.
 #
 # Detection:
 #   schedule / workflow_dispatch  -> all images
@@ -184,7 +185,7 @@ jobs:
       - name: CalVer date
         id: date
         shell: bash
-        run: echo "calver=$(date -u +%Y.%m.%d)" >> "${GITHUB_OUTPUT}"
+        run: echo "calver=$(date -u +%Y.%-m.%-d)" >> "${GITHUB_OUTPUT}"
 
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
`date -u +%Y.%m.%d` zero-pads, producing tags like `2026.07.27`. Leading zeros are invalid in semver numeric identifiers, so Renovate's `semver-coerced` versioning rejects the tag and falls through to digest-only checks. Confirmed in a live Renovate run against `coder-config`:

```
DEBUG: Dependency ghcr.io/bendwyer/coder-images/coder-base has
unsupported/unversioned value 2026.06.15 (versioning=semver-coerced)
```

Effect: `coder-config` sat pinned to `coder-base:2026.06.15` for six weeks and Renovate never opened a single bump PR for it, so workspaces ran a Claude Code six weeks behind what `coder-images` had already built and published. The image pipeline itself was healthy the whole time.

`%-m`/`%-d` yields `2026.7.27`, which is valid semver, so consumers need no versioning override at all.

Scope is contained: this is the only workflow in the repo using `%Y`, and `coder-images` is its only caller.

Verified the format on a GNU coreutils host: `date -u +%Y.%-m.%-d` gives `2026.7.27`.

Follow-up required, since this does not unstick the existing pin on its own: the current `2026.06.15` value stays unversioned, so `coder-config` needs one manual pin bump to a new unpadded tag before Renovate can take over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)