### PR TITLE
fix(k8s-monitoring-publish-oci): emit unpadded CalVer tags

### DIFF
--- a/.github/workflows/k8s-monitoring-publish-oci.yml
+++ b/.github/workflows/k8s-monitoring-publish-oci.yml
@@ -111,13 +111,15 @@ jobs:
             version=$(echo "$line" | jq -r '.version' | sed 's/^version-//; s/^v//')
 
             # For SHA-pinned deps (monorepo mixins without upstream semver tags),
-            # convert to YYYY.MM.DD using the upstream commit date so the OCI tag
-            # is semver-coerce friendly for downstream Renovate consumers.
+            # convert to CalVer `YYYY.MM.DD` using the upstream commit date.
+            # CalVer `MM`/`DD`, not `0M`/`0D`: leading zeros are invalid semver, so
+            # a padded tag is unversioned to `semver-coerced` and downstream
+            # Renovate silently never bumps it.
             if [[ "$version" =~ ^[0-9a-f]{40}$ ]]; then
               owner_repo=$(echo "$remote" | sed -E 's|https://github\.com/([^/]+/[^/.]+).*|\1|')
-              commit_date=$(gh api "repos/${owner_repo}/commits/${version}" --jq '.commit.committer.date' 2>/dev/null | cut -d'T' -f1 | tr - .)
+              commit_date=$(gh api "repos/${owner_repo}/commits/${version}" --jq '.commit.committer.date' 2>/dev/null | cut -d'T' -f1)
               if [ -n "$commit_date" ]; then
-                version="$commit_date"
+                version=$(date -d "$commit_date" +%Y.%-m.%-d)
               fi
             fi
 


### PR DESCRIPTION
Same defect as #176, in the other generator.

The SHA-pinned-dep branch converts an upstream commit date into a CalVer tag, and its own comment says this exists "so the OCI tag is semver-coerce friendly for downstream Renovate consumers". But `cut -d'T' -f1 | tr - .` inherits ISO zero-padding, producing tags like `2026.03.24`. Leading zeros are invalid in semver numeric identifiers, so `semver-coerced` treats the tag as unversioned and silently skips version updates. The padding defeated the only thing the conversion was written to do.

Formats the date explicitly as CalVer `MM`/`DD` rather than `0M`/`0D`. Both are valid CalVer per calver.org, where `MM`/`DD` are the short variants; only the unpadded one is also valid semver.

Verified across edge cases:

```
2026-03-24 -> 2026.3.24
2026-05-18 -> 2026.5.18
2025-10-23 -> 2025.10.23   (already unpadded, unchanged)
2026-01-01 -> 2026.1.1
2026-11-09 -> 2026.11.9
```

`cut -d'T' -f1` is kept ahead of `date -d` so the input is a bare date and no timezone conversion can shift the day. Only the padding changes.

Note for consumers: this fixes tags generated from here on. An existing padded pin stays unversioned, so Renovate still cannot compute an update from it and each one needs a single manual bump to an unpadded tag before it starts tracking again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)